### PR TITLE
Bug Report

### DIFF
--- a/script.js
+++ b/script.js
@@ -3,23 +3,40 @@ function clr() {
 }
 
 function element(val) {
-    document.getElementById("result").value += val;
+    const display = document.getElementById("result");
+
+    // Якщо зараз показано "Error" — очищаємо перед додаванням нового символу
+    if (display.value === "Error") {
+        display.value = "";
+    }
+
+    display.value += val;
 }
 
 function res() {
-    let x = document.getElementById("result").value;
+    const display = document.getElementById("result");
+    const x = display.value;
+
     try {
-        let y = math.evaluate(x);
-        document.getElementById("result").value = y;
+        const y = math.evaluate(x);
+        display.value = y;
     } catch (e) {
-        document.getElementById("result").value = "Error";
+        display.value = "Error";
     }
 }
 
+// Додаємо очищення при натисканні клавіш
 document.getElementById("result").addEventListener("keyup", function(event) {
+    const display = document.getElementById("result");
     const allowedKeys = ['0','1','2','3','4','5','6','7','8','9','+','-','*','/','.'];
+
+    // Якщо користувач починає нове введення після помилки — очищаємо поле
+    if (display.value === "Error" && allowedKeys.includes(event.key)) {
+        display.value = "";
+    }
+
     if (allowedKeys.includes(event.key)) {
-        document.getElementById("result").value += event.key;
+        display.value += event.key;
     } else if (event.key === "Enter") {
         res();
     }


### PR DESCRIPTION
**Опис недоліку**: Після введення некоректного виразу калькулятор показує повідомлення Error.
Однак при введенні нового прикладу повідомлення не зникає автоматично — користувачу потрібно вручну очищати поле.ри вводі

**Кроки для відтворення:**
Ввести некоректний приклад, наприклад 2++2.
Натиснути = — з’являється Error.
Почати вводити новий приклад (наприклад, 3+3) — текст Error не зникає, і потрібно вручну очищати поле.

**Очікувана поведінка:**
Після введення нового символу після помилки поле має очищатися автоматично.

**Фактична поведінка:**
Повідомлення Error залишається, поки користувач сам не натисне C (очищення).

**Моє рішення:**
Додано перевірку: якщо в полі result є текст "Error", він автоматично очищається при введенні нового символу.
Це дозволяє користувачу вводити новий приклад без необхідності очищати поле вручну.

**Результат:**
Після оновлення script.js повідомлення Error тепер зникає автоматично при введенні нового прикладу, і калькулятор працює зручніше.